### PR TITLE
game: entity: collider: collider-qtree: исправление сборки с GCC 13

### DIFF
--- a/src/game/entity/collider/collider-qtree.hpp
+++ b/src/game/entity/collider/collider-qtree.hpp
@@ -28,7 +28,7 @@ public:
 
   /// хешер для collision_pairs
   struct Collision_pairs_hash {
-    inline static std::size_t operator()(const Collision_pair val) {
+    inline std::size_t operator() const (const Collision_pair val) {
       // сделать поинтеры числом и юзать это как уникальный ID
       cauto a = std::bit_cast<std::uintptr_t>(val.first);
       cauto b = std::bit_cast<std::uintptr_t>(val.second);


### PR DESCRIPTION
При сборке GCC выдаёт такую ошибку: 
```
src/game/entity/collider/collider-qtree.hpp:31:31: error: 'static std::size_t Collider_qtree::Collision_pairs_hash::operator()(Collider_qtree::Collision_pair)' must be a non-static member function
   31 |     inline static std::size_t operator()(const Collision_pair val) {
```

Однако просто убрать static с operator метода нельзя, тогда появляется ошибка в robin_hood.h:
```
thirdparty/include/robin-hood-hashing/robin_hood.h:1352:57: error: passing 'const robin_hood::detail::Table<true, 80, std::pair<Entity*, Entity*>, void, Collider_qtree::Collision_pairs_hash, std::equal_to<std::pair<Entity*, Entity*> > >' as 'this' argument discards qualifiers [-fpermissive]
 1352 |         auto h = static_cast<uint64_t>(WHash::operator()(key));
```

Поэтому с одной стороны удалён static, а с другой добавлен const.